### PR TITLE
feat-7: 홈 화면 퍼블리싱 (카카오맵 지도 연결 ) 및 BottomNav 바 공통 컴포넌트 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,400,0,0"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/components/KakaoMap.tsx
+++ b/src/components/KakaoMap.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+
+export default function KakaoMap() {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const KEY = import.meta.env.VITE_KAKAO_MAP_KEY;
+    if (!KEY || !mapRef.current) return;
+
+    const loadScript = (src: string) =>
+      new Promise<void>((resolve, reject) => {
+        const s = document.createElement("script");
+        s.src = src;
+        s.async = true;
+        s.onload = () => resolve();
+        s.onerror = () => reject(new Error(`load failed: ${src}`));
+        document.head.appendChild(s);
+      });
+
+    const init = async () => {
+      await loadScript(
+        `https://dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${KEY}`
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const kakao = (window as any)?.kakao;
+      if (!kakao?.maps) return;
+
+      kakao.maps.load(() => {
+        const center = new kakao.maps.LatLng(35.8889, 128.6109); // 경북대
+        const map = new kakao.maps.Map(mapRef.current, {
+          center,
+          level: 4,
+        });
+
+        new kakao.maps.Marker({ map, position: center });
+      });
+    };
+
+    init();
+  }, []);
+
+  return <div ref={mapRef} className="h-[600px] w-full rounded-t-lg" />;
+}

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -16,18 +16,18 @@ export default function BottomNav() {
   return (
     <nav
       className="fixed bottom-0 left-0 right-0 z-50 mx-auto w-full max-w-[720px]
-                 border-t border-neutral-200 bg-white/95 backdrop-blur
-                 supports-[backdrop-filter]:bg-white/75 px-16 py-2
-                 pb-[calc(env(safe-area-inset-bottom,0)+0.5rem)]"
+             border-t border-neutral-200 bg-white/95 backdrop-blur
+             supports-[backdrop-filter]:bg-white/75 px-4 sm:px-8 md:px-16 py-2
+             pb-[calc(env(safe-area-inset-bottom,0)+0.5rem)]"
       aria-label="하단 네비게이션"
     >
-      <ul className="flex items-center justify-between">
+      <ul className="flex items-center justify-between gap-1">
         {items.map(({ label, path, icon: Icon }) => {
           const active = pathname.startsWith(path);
           return (
             <li
               key={path}
-              className="flex w-16 flex-col items-center justify-center"
+              className="flex flex-1 basis-1/5 min-w-[56px] flex-col items-center justify-center"
             >
               <button
                 type="button"
@@ -37,10 +37,10 @@ export default function BottomNav() {
                 aria-label={label}
               >
                 <Icon
-                  className={`h-6 w-6 ${active ? "text-blue-600" : "text-neutral-400"}`}
+                  className={`h-8 w-8 ${active ? "text-blue-600" : "text-neutral-400"}`}
                 />
                 <span
-                  className={`mt-0.5 text-[10px] font-bold leading-4 ${active ? "text-blue-600" : "text-neutral-400"}`}
+                  className={`mt-0.5 text-[13px] font-bold leading-4 ${active ? "text-blue-600" : "text-neutral-400"}`}
                 >
                   {label}
                 </span>
@@ -60,11 +60,15 @@ export function BottomNavSpacer() {
 
 /* ---- 간단 아이콘 ---- */
 function HomeIcon({ className = "" }) {
-  return <span className={`material-symbols-outlined ${className}`}>home</span>;
+  return (
+    <span className={`material-symbols-outlined text-[28px] ${className}`}>
+      home
+    </span>
+  );
 }
 function ListIcon({ className = "" }) {
   return (
-    <span className={`material-symbols-outlined ${className}`}>
+    <span className={`material-symbols-outlined text-[28px] ${className}`}>
       calendar_month
     </span>
   );
@@ -72,12 +76,14 @@ function ListIcon({ className = "" }) {
 
 function PlusIcon({ className = "" }) {
   return (
-    <span className={`material-symbols-outlined ${className}`}>add_circle</span>
+    <span className={`material-symbols-outlined text-[28px] ${className}`}>
+      add_circle
+    </span>
   );
 }
 function UserIcon({ className = "" }) {
   return (
-    <span className={`material-symbols-outlined ${className}`}>
+    <span className={`material-symbols-outlined text-[28px] ${className}`}>
       account_circle
     </span>
   );

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,0 +1,84 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { ROUTE_PATH } from "@/routes/paths";
+
+const items = [
+  { label: "홈", path: ROUTE_PATH.HOME, icon: HomeIcon },
+  { label: "예약 내역", path: ROUTE_PATH.RESERVATIONS, icon: ListIcon },
+  { label: "공간 등록", path: ROUTE_PATH.REGISTER, icon: PlusIcon },
+  { label: "마이 페이지", path: ROUTE_PATH.MYPAGE, icon: UserIcon },
+];
+
+/** 필요한 페이지에서 직접 렌더링해서 사용하세요. */
+export default function BottomNav() {
+  const { pathname } = useLocation();
+  const nav = useNavigate();
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 mx-auto w-full max-w-[720px]
+                 border-t border-neutral-200 bg-white/95 backdrop-blur
+                 supports-[backdrop-filter]:bg-white/75 px-16 py-2
+                 pb-[calc(env(safe-area-inset-bottom,0)+0.5rem)]"
+      aria-label="하단 네비게이션"
+    >
+      <ul className="flex items-center justify-between">
+        {items.map(({ label, path, icon: Icon }) => {
+          const active = pathname.startsWith(path);
+          return (
+            <li
+              key={path}
+              className="flex w-16 flex-col items-center justify-center"
+            >
+              <button
+                type="button"
+                onClick={() => nav(path)}
+                className="flex flex-col items-center justify-center outline-none"
+                aria-current={active ? "page" : undefined}
+                aria-label={label}
+              >
+                <Icon
+                  className={`h-6 w-6 ${active ? "text-blue-600" : "text-neutral-400"}`}
+                />
+                <span
+                  className={`mt-0.5 text-[10px] font-bold leading-4 ${active ? "text-blue-600" : "text-neutral-400"}`}
+                >
+                  {label}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+/** 콘텐츠가 네비게이션에 가리지 않도록 여백 확보용 스페이서 */
+export function BottomNavSpacer() {
+  return <div className="h-16" />; // 필요하면 높이 조정
+}
+
+/* ---- 간단 아이콘 ---- */
+function HomeIcon({ className = "" }) {
+  return <span className={`material-symbols-outlined ${className}`}>home</span>;
+}
+function ListIcon({ className = "" }) {
+  return (
+    <span className={`material-symbols-outlined ${className}`}>
+      calendar_month
+    </span>
+  );
+}
+
+function PlusIcon({ className = "" }) {
+  return (
+    <span className={`material-symbols-outlined ${className}`}>add_circle</span>
+  );
+}
+function UserIcon({ className = "" }) {
+  return (
+    <span className={`material-symbols-outlined ${className}`}>
+      account_circle
+    </span>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,143 @@
+import BottomNav from "@/components/layout/BottomNav";
+
+type Spot = {
+  id: string;
+  name: string;
+  pricePoint: number; // P
+  unit: string; // "/시간"
+  manner: string; // "85°C"
+  image?: string;
+};
+
+const dummySpots: Spot[] = [
+  {
+    id: "1",
+    name: "엘레강스 빌",
+    pricePoint: 2500,
+    unit: "/시간",
+    manner: "85°C",
+  },
+  {
+    id: "2",
+    name: "엘레강스 빌",
+    pricePoint: 2500,
+    unit: "/시간",
+    manner: "85°C",
+  },
+];
+
+export default function HomePage() {
+  return (
+    <div className="relative w-full min-h-dvh bg-zinc-50">
+      {/* 상단 지도(이미지) */}
+      <div className="relative flex h-[394px] w-full overflow-hidden rounded-t-lg">
+        <img
+          src="https://placehold.co/389x394"
+          alt="map"
+          className="h-full w-full object-cover"
+        />
+      </div>
+      {/* 아래 패널 */}
+      <section className="relative -mt-2 w-full rounded-t-md bg-gray-100 p-2">
+        {/* 필터 카드 */}
+        <div className="mx-auto mb-3 w-full max-w-[389px] rounded-xl bg-white p-1 shadow-[0_0_8px_rgba(0,0,0,0.25)]">
+          {/* 시간/날짜 범위 - 스켈레톤 형태 */}
+          <div className="flex h-9 items-center justify-center gap-2">
+            <div className="flex w-[318px] items-center gap-2">
+              <div className="h-5 w-36 rounded bg-gray-200" />
+              <span className="text-[10px] font-bold leading-4 text-black">
+                ~
+              </span>
+              <div className="h-5 w-36 rounded bg-gray-200" />
+            </div>
+            <button
+              type="button"
+              className="grid h-3.5 w-3.5 place-items-center rounded-[2px] bg-blue-500 p-1"
+              aria-label="검색"
+            >
+              <svg width="8" height="8" viewBox="0 0 24 24" fill="white">
+                <path d="M21 20l-5.2-5.2a7 7 0 10-1.4 1.4L20 21l1-1zM4 10a6 6 0 1112 0A6 6 0 014 10z" />
+              </svg>
+            </button>
+          </div>
+
+          {/* 가격 범위 */}
+          <div className="px-1 py-2">
+            <div className="mb-1 flex items-center gap-1 px-1">
+              <span className="text-[10px] font-semibold leading-4 text-black">
+                가격 범위
+              </span>
+            </div>
+            <div className="flex h-6 items-center gap-2">
+              <div className="h-5 w-[150px] rounded bg-gray-200" />
+              <span className="text-[10px] font-bold leading-4 text-black">
+                ~
+              </span>
+              <div className="h-5 w-[150px] rounded bg-gray-200" />
+            </div>
+          </div>
+        </div>
+
+        {/* 섹션 타이틀 */}
+        <div className="mx-auto flex h-[22px] w-full max-w-[389px] items-center px-2.5">
+          <h2 className="text-[16px] font-bold leading-4 text-black">
+            근처 주차 공간
+          </h2>
+        </div>
+
+        {/* 리스트 */}
+        <div className="mx-auto grid w-full max-w-[389px] gap-3 pb-28">
+          {dummySpots.map((s) => (
+            <SpotCard key={s.id} spot={s} />
+          ))}
+        </div>
+      </section>
+      <BottomNav />
+    </div>
+  );
+}
+
+function SpotCard({ spot }: { spot: Spot }) {
+  return (
+    <div className="flex h-[90px] w-full items-center gap-2 rounded-lg bg-white p-1 shadow-[0_0_8px_rgba(0,0,0,0.25)]">
+      <div className="h-20 w-[98px] rounded-lg bg-orange-50" />
+      <div className="flex h-[74px] w-[240px] flex-col items-start justify-center gap-1 p-1">
+        <div>
+          <p className="text-[20px] font-bold leading-4 text-black">
+            {spot.name}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <span className="text-[15px] font-bold leading-4 text-blue-500">
+            {spot.pricePoint}P
+          </span>
+          <span className="text-[12px] font-semibold leading-4 text-neutral-600">
+            {spot.unit}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1 py-1 pr-1">
+          {/* 온도 아이콘 대체 */}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            className="text-amber-500"
+          >
+            <path
+              fill="#FFA629"
+              d="M13 15.1V5a1 1 0 10-2 0v10.1a3.5 3.5 0 102 0z"
+            />
+          </svg>
+          <span className="text-[10px] font-semibold leading-4 text-amber-500">
+            {spot.manner}
+          </span>
+          <span className="text-[10px] font-semibold leading-4 text-gray-500">
+            매너 온도
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import BottomNav from "@/components/layout/BottomNav";
+import KakaoMap from "@/components/KakaoMap";
 
 type Spot = {
   id: string;
@@ -28,70 +29,64 @@ const dummySpots: Spot[] = [
 
 export default function HomePage() {
   return (
-    <div className="relative w-full min-h-dvh bg-zinc-50">
-      {/* 상단 지도(이미지) */}
-      <div className="relative flex h-[394px] w-full overflow-hidden rounded-t-lg">
-        <img
-          src="https://placehold.co/389x394"
-          alt="map"
-          className="h-full w-full object-cover"
-        />
-      </div>
+    <div className="relative min-h-dvh w-full bg-zinc-50 pb-24">
+      <KakaoMap />
+
       {/* 아래 패널 */}
-      <section className="relative -mt-2 w-full rounded-t-md bg-gray-100 p-2">
+      <section className="relative -mt-2 w-full rounded-t-md py-3">
         {/* 필터 카드 */}
-        <div className="mx-auto mb-3 w-full max-w-[389px] rounded-xl bg-white p-1 shadow-[0_0_8px_rgba(0,0,0,0.25)]">
-          {/* 시간/날짜 범위 - 스켈레톤 형태 */}
-          <div className="flex h-9 items-center justify-center gap-2">
-            <div className="flex w-[318px] items-center gap-2">
-              <div className="h-5 w-36 rounded bg-gray-200" />
+        <div className="w-full rounded-xl bg-white p-3 shadow-[0_0_8px_rgba(0,0,0,0.25)]">
+          {/* 시간 범위 */}
+          <div className="flex h-9 items-center justify-between gap-2">
+            <div className="flex flex-1 items-center gap-2">
+              <div className="h-5 flex-1 rounded bg-gray-200" />
               <span className="text-[10px] font-bold leading-4 text-black">
                 ~
               </span>
-              <div className="h-5 w-36 rounded bg-gray-200" />
+              <div className="h-5 flex-1 rounded bg-gray-200" />
             </div>
             <button
               type="button"
-              className="grid h-3.5 w-3.5 place-items-center rounded-[2px] bg-blue-500 p-1"
+              className="grid h-6 w-6 place-items-center rounded bg-blue-500"
               aria-label="검색"
             >
-              <svg width="8" height="8" viewBox="0 0 24 24" fill="white">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="white">
                 <path d="M21 20l-5.2-5.2a7 7 0 10-1.4 1.4L20 21l1-1zM4 10a6 6 0 1112 0A6 6 0 014 10z" />
               </svg>
             </button>
           </div>
 
           {/* 가격 범위 */}
-          <div className="px-1 py-2">
-            <div className="mb-1 flex items-center gap-1 px-1">
+          <div className="mt-3">
+            <div className="mb-1 px-1">
               <span className="text-[10px] font-semibold leading-4 text-black">
                 가격 범위
               </span>
             </div>
-            <div className="flex h-6 items-center gap-2">
-              <div className="h-5 w-[150px] rounded bg-gray-200" />
+            <div className="flex items-center gap-2">
+              <div className="h-5 flex-1 rounded bg-gray-200" />
               <span className="text-[10px] font-bold leading-4 text-black">
                 ~
               </span>
-              <div className="h-5 w-[150px] rounded bg-gray-200" />
+              <div className="h-5 flex-1 rounded bg-gray-200" />
             </div>
           </div>
         </div>
 
         {/* 섹션 타이틀 */}
-        <div className="mx-auto flex h-[22px] w-full max-w-[389px] items-center px-2.5">
-          <h2 className="text-[16px] font-bold leading-4 text-black">
-            근처 주차 공간
-          </h2>
-        </div>
+        <h2 className="mt-8 mb-4 text-[16px] font-bold leading-4 text-black">
+          근처 주차 공간
+        </h2>
 
         {/* 리스트 */}
-        <div className="mx-auto grid w-full max-w-[389px] gap-3 pb-28">
+        <div className="grid gap-3">
           {dummySpots.map((s) => (
             <SpotCard key={s.id} spot={s} />
           ))}
         </div>
       </section>
+
+      {/* 선택적: 스페이서 대신 컨테이너 pb-24로 처리 */}
       <BottomNav />
     </div>
   );
@@ -99,16 +94,17 @@ export default function HomePage() {
 
 function SpotCard({ spot }: { spot: Spot }) {
   return (
-    <div className="flex h-[90px] w-full items-center gap-2 rounded-lg bg-white p-1 shadow-[0_0_8px_rgba(0,0,0,0.25)]">
-      <div className="h-20 w-[98px] rounded-lg bg-orange-50" />
-      <div className="flex h-[74px] w-[240px] flex-col items-start justify-center gap-1 p-1">
-        <div>
-          <p className="text-[20px] font-bold leading-4 text-black">
-            {spot.name}
-          </p>
-        </div>
+    <div className="flex w-full items-center gap-3 rounded-2xl bg-white p-3 shadow-[0_0_8px_rgba(0,0,0,0.2)]">
+      {/* 썸네일 */}
+      <div className="h-16 w-20 flex-shrink-0 rounded-xl bg-orange-50" />
 
-        <div className="flex items-center gap-1">
+      {/* 본문 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="truncate text-[20px] font-bold leading-5 text-black">
+          {spot.name}
+        </p>
+
+        <div className="flex items-baseline gap-1">
           <span className="text-[15px] font-bold leading-4 text-blue-500">
             {spot.pricePoint}P
           </span>
@@ -117,8 +113,7 @@ function SpotCard({ spot }: { spot: Spot }) {
           </span>
         </div>
 
-        <div className="flex items-center gap-1 py-1 pr-1">
-          {/* 온도 아이콘 대체 */}
+        <div className="flex items-center gap-1 pt-1 text-[10px]">
           <svg
             width="12"
             height="12"
@@ -130,12 +125,8 @@ function SpotCard({ spot }: { spot: Spot }) {
               d="M13 15.1V5a1 1 0 10-2 0v10.1a3.5 3.5 0 102 0z"
             />
           </svg>
-          <span className="text-[10px] font-semibold leading-4 text-amber-500">
-            {spot.manner}
-          </span>
-          <span className="text-[10px] font-semibold leading-4 text-gray-500">
-            매너 온도
-          </span>
+          <span className="font-semibold text-amber-500">{spot.manner}</span>
+          <span className="font-semibold text-gray-500">매너 온도</span>
         </div>
       </div>
     </div>

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,3 +1,7 @@
 export const ROUTE_PATH = {
-  MAIN: "/",
+  ONBOARDING: "/", // 시작 화면
+  HOME: "/home", // 지도/메인 페이지
+  RESERVATIONS: "/reservations", // 예약 내역
+  REGISTER: "/register", // 공간 등록
+  MYPAGE: "/mypage", // 마이 페이지
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,19 +1,21 @@
 import { Routes, Route } from "react-router-dom";
-// If the correct path is "@/routes/path", update as follows:
 import { ROUTE_PATH } from "@/routes/paths";
 
 import OnboardingPage from "@/pages/OnboardingPage";
+import HomePage from "@/pages/HomePage";
+// 추후 생성될 페이지 더미
+const ReservationsPage = () => <div>예약 내역 페이지</div>;
+const RegisterPage = () => <div>공간 등록 페이지</div>;
+const MyPage = () => <div>마이 페이지</div>;
 
-const Router = () => {
+export default function AppRouter() {
   return (
     <Routes>
-      {/* 온보딩 (앱 진입 시 첫 화면) */}
-      <Route path={ROUTE_PATH.MAIN} element={<OnboardingPage />} />
-      {/* 사용자 영역 */}
-
-      {/* 오너 영역 */}
+      <Route path={ROUTE_PATH.ONBOARDING} element={<OnboardingPage />} />
+      <Route path={ROUTE_PATH.HOME} element={<HomePage />} />
+      <Route path={ROUTE_PATH.RESERVATIONS} element={<ReservationsPage />} />
+      <Route path={ROUTE_PATH.REGISTER} element={<RegisterPage />} />
+      <Route path={ROUTE_PATH.MYPAGE} element={<MyPage />} />
     </Routes>
   );
-};
-
-export default Router;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+  },
   resolve: {
     alias: {
       "@": "/src",


### PR DESCRIPTION
## ✨ 요약

> 홈 화면 상단에 카카오맵을 연결하고, 하단 네비게이션 바를 공통 컴포넌트로 추가했습니다.

## 🔗 작업 내용

- KakaoMap.tsx 컴포넌트 구현 및 HomePage에 적용
- HomePage 레이아웃 퍼블리싱 (임시 이미지 → 카카오맵으로 교체)
- BottomNav 공통 컴포넌트 추가 및 아이콘/텍스트 반응형 적용

## 💻 상세 구현 내용

- KakaoMap.tsx:
   - 카카오 지도 SDK를 동적으로 로드하고, 기본 중심 좌표를 경북대학교로 설정
   - 초기 마커를 표시하도록 구성
- HomePage.tsx:
   - 상단 지도 영역을 KakaoMap으로 교체
   - 하단 여백(pb-24) 추가로 BottomNav와 겹치지 않도록 수정
- BottomNav.tsx:
   - 공통 네비게이션 컴포넌트로 분리
   - Material Symbols 기반 아이콘 + 반응형 크기 적용
   - 각 페이지 이동 라우팅 연동

## 🔗 참고 사항

- 카카오 API Key는 .env의 VITE_KAKAO_MAP_KEY 값 필요
- Material Symbols 아이콘을 사용하기 위해 index.html에 Google Fonts 링크 추가
- 공통 컴포넌트 BottomNav 추가해뒀으니 HomePage.tsx에서 사용하신 부분 참고하시면 될 것 같습니다!

## 📸 스크린샷 (Screenshots)

<img width="1502" height="948" alt="스크린샷 2025-09-10 오전 1 30 37" src="https://github.com/user-attachments/assets/a264ba50-aec2-4fd6-9ab2-2d9427651c61" />

- 현재 지도가 너무 작아보여서 height 값을 250px -> 600px 정도로 키웠습니다
<img width="1494" height="947" alt="스크린샷 2025-09-10 오전 1 30 20" src="https://github.com/user-attachments/assets/692e39a1-b833-402c-92ed-b2ee32a9a99e" />

## 🔗 관련 이슈

- Close #7 
