### PR TITLE
feat: 파일 업로드, 교체 삭제 버튼 추가

### DIFF
--- a/src/pages/owner/SpacesPageStep1.tsx
+++ b/src/pages/owner/SpacesPageStep1.tsx
@@ -114,7 +114,7 @@ export default function SpacesPageStep1() {
             </div>
 
             {/* 다음 버튼: sticky로 하단 고정 (스크롤 상단에 붙음) */}
-            <div className="w-full sticky bottom-[calc(72px+env(safe-area-inset-bottom))] bg-neutral-50/95 backdrop-blur supports-[backdrop-filter]:bg-neutral-50/80 pt-2">
+            <div className="w-full sticky pb-6 bottom-[calc(72px+env(safe-area-inset-bottom))] bg-neutral-50/95 backdrop-blur supports-[backdrop-filter]:bg-neutral-50/80 pt-2">
               <PrimaryButton
                 onClick={() => navigate(ROUTE_PATH.REGISTER_STEP2)}
               >


### PR DESCRIPTION
✨ 요약

주차 공간 등록 2단계에서 이미지 업로드 및 저장 로직을 구현하여 사용자가 사진을 선택하고 다음 단계로 진행할 수 있도록 기능을 추가했습니다.

🔗 작업 내용
	•	업로드 슬롯(최대 4개)에 파일 선택, 미리보기, 교체, 삭제 기능 구현
	•	업로드된 파일에 대한 유효성 검증(이미지 여부, 최대 10MB 제한) 추가
	•	“다음” 버튼 클릭 시 선택된 이미지들을 저장(sessionStorage)하고 다음 단계로 이동하는 로직 구현

💻 상세 구현 내용
	•	각 업로드 슬롯은 숨겨진 <input type="file" />를 useRef로 제어하여 버튼 클릭 시 파일 선택 창이 열리도록 구성
	•	useMemo를 활용해 업로드된 파일을 URL.createObjectURL로 변환하여 썸네일 미리보기 제공
	•	파일 교체 및 삭제 기능을 추가해 사용자가 업로드 이미지를 자유롭게 수정 가능
	•	선택된 파일은 onNext 함수 실행 시 uploadImages 로직을 통해 가공되며, 현재는 sessionStorage에 URL 배열을 저장하는 임시 구현
	•	실제 서버 연동 시 FormData와 fetch 요청으로 교체 가능하도록 주석 처리된 코드 포함
	•	업로드 중에는 버튼을 비활성화하고 "업로드 중..." 문구를 표시하여 상태 관리 강화

🔗 참고 사항
	•	현재는 sessionStorage를 통한 임시 저장 방식으로 구현되어 있으며, 추후 백엔드 API 연동 시 교체 필요
	•	업로드한 파일의 URL은 Step3 페이지에서 활용 가능하도록 저장됨

🔗 관련 이슈
	•	Close #21 