### PR TITLE
feat:  시간 선택 드롭다운 구현

### DIFF
--- a/src/pages/owner/SpacesPageStep3.tsx
+++ b/src/pages/owner/SpacesPageStep3.tsx
@@ -9,6 +9,38 @@ import { ROUTE_PATH } from "@/routes/paths";
 
 export default function SpacesPageStep3() {
   const navigate = useNavigate();
+
+  const periods = ["오전", "오후"] as const;
+  const hours = React.useMemo(
+    () => Array.from({ length: 12 }, (_, i) => i + 1),
+    []
+  );
+
+  type Period = (typeof periods)[number];
+
+  const [startPeriod, setStartPeriod] = React.useState<Period>("오전");
+  const [startHour, setStartHour] = React.useState<number>(9); // 기본 09시
+  const [endPeriod, setEndPeriod] = React.useState<Period>("오후");
+  const [endHour, setEndHour] = React.useState<number>(6); // 기본 18시
+
+  // 오전/오후 + 1~12시 -> 0~23시 변환
+  const to24h = (p: Period, h12: number) => {
+    const isAM = p === "오전";
+    if (isAM) return h12 === 12 ? 0 : h12; // 12AM => 0
+    return h12 === 12 ? 12 : h12 + 12; // 12PM => 12
+  };
+
+  const handleNext = () => {
+    const s = to24h(startPeriod, startHour);
+    const e = to24h(endPeriod, endHour);
+    if (s >= e) {
+      window.alert("종료 시간은 시작 시간보다 커야 합니다.");
+      return;
+    }
+    // TODO: 전역 상태/서버 전송이 필요하면 여기서 s,e 값을 사용해 저장하세요.
+    navigate(ROUTE_PATH.REGISTER_STEP4);
+  };
+
   return (
     <div className="min-h-svh w-full bg-zinc-50">
       <div className="relative mx-auto min-h-svh w-full max-w-[420px] sm:max-w-[480px] md:max-w-[640px] flex flex-col items-stretch overflow-hidden">
@@ -21,7 +53,7 @@ export default function SpacesPageStep3() {
             {/* 안내 문구 */}
             <div className="w-full p-1 inline-flex justify-start items-center gap-2.5 overflow-hidden">
               <div className="flex justify-start items-center gap-2.5 overflow-hidden">
-                <div className="justify-center text-black text-base font-bold font-['Pretendard'] leading-7">
+                <div className="justify-center text-black text-base font-bold leading-7">
                   언제 대여가 가능한가요?
                 </div>
               </div>
@@ -38,16 +70,70 @@ export default function SpacesPageStep3() {
                   </div>
                 </div>
 
-                <div className="w-full px-1 inline-flex justify-start items-center gap-2.5">
-                  <div className="w-full h-8 bg-neutral-200 rounded border border-neutral-400" />
+                {/* AM/PM(3) + 시각(7)  ~  AM/PM(3) + 시각(7) */}
+                <div className="w-full px-1 inline-flex justify-start items-center gap-1">
+                  {/* 시작 - 오전/오후 */}
+                  <select
+                    aria-label="시작 오전/오후"
+                    value={startPeriod}
+                    onChange={(e) => setStartPeriod(e.target.value as Period)}
+                    className="flex-[3] h-8 bg-white rounded border border-neutral-400 px-2 text-sm outline-none focus:outline-none focus:ring-0"
+                  >
+                    {periods.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                  </select>
 
-                  <div className="shrink-0 px-1 flex items-center">
+                  {/* 시작 - 시각 */}
+                  <select
+                    aria-label="시작 시각"
+                    value={startHour}
+                    onChange={(e) => setStartHour(Number(e.target.value))}
+                    className="flex-[7] h-8 bg-white rounded border border-neutral-400 px-2 text-sm outline-none focus:outline-none focus:ring-0"
+                  >
+                    {hours.map((h) => (
+                      <option key={h} value={h}>
+                        {String(h).padStart(2, "0")}:00
+                      </option>
+                    ))}
+                  </select>
+
+                  {/* 구분자 */}
+                  <div className="shrink-0 px-3 flex items-center">
                     <span className="text-black text-base font-semibold leading-none">
                       ~
                     </span>
                   </div>
 
-                  <div className="w-full h-8 bg-neutral-200 rounded border border-neutral-400" />
+                  {/* 종료 - 오전/오후 */}
+                  <select
+                    aria-label="종료 오전/오후"
+                    value={endPeriod}
+                    onChange={(e) => setEndPeriod(e.target.value as Period)}
+                    className="flex-[3] h-8 bg-white rounded border border-neutral-400 px-2 text-sm outline-none focus:outline-none focus:ring-0"
+                  >
+                    {periods.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                  </select>
+
+                  {/* 종료 - 시각 */}
+                  <select
+                    aria-label="종료 시각"
+                    value={endHour}
+                    onChange={(e) => setEndHour(Number(e.target.value))}
+                    className="flex-[7] h-8 bg-white rounded border border-neutral-400 px-2 text-sm outline-none focus:outline-none focus:ring-0"
+                  >
+                    {hours.map((h) => (
+                      <option key={h} value={h}>
+                        {String(h).padStart(2, "0")}:00
+                      </option>
+                    ))}
+                  </select>
                 </div>
               </div>
             </div>
@@ -65,7 +151,7 @@ export default function SpacesPageStep3() {
               <PrimaryButton
                 fullWidth={false}
                 className="flex-1"
-                onClick={() => navigate(ROUTE_PATH.REGISTER_STEP4)}
+                onClick={handleNext}
               >
                 다음
               </PrimaryButton>


### PR DESCRIPTION
✨ 요약

주차 공간 등록 시 대여 가능 시간을 입력받을 수 있도록 오전/오후 + 시각 드롭다운 컴포넌트를 구현하고, 추후 백엔드 연동 시 24시간제로 변환하여 저장할 수 있는 로직을 준비했습니다.

🔗 작업 내용
	•	시간 선택 UI를 오전/오후(AM/PM) + 시각 드롭다운 형태로 구현
	•	시작/종료 시간에 대한 검증 로직(시작 < 종료) 추가
	•	선택된 시간을 24시간제로 변환하는 헬퍼 함수 작성 (백엔드 저장 시 활용 예정)
	•	UX 개선을 위해 드롭다운 포커스 스타일 및 클릭 시 포커스 동작 제어

💻 상세 구현 내용
	•	periods = [오전, 오후], hours = 1~12 배열을 기반으로 <select> 드롭다운 옵션을 생성
	•	시작/종료 시간을 각각 **오전/오후 + 시각(3:7 비율)**로 입력받을 수 있도록 flex 비율로 배치
	•	to24h(period, hour) 함수를 통해 입력값을 24시간제 숫자로 변환 (예: 오전 12시 → 0, 오후 3시 → 15)
	•	handleNext에서 검증 후, 유효하면 24시간제 값으로 변환 → 추후 전역 상태나 API 호출 시 이 값을 그대로 백엔드에 전달 가능
	•	UX 보완: onFocus={(e) => e.target.blur()} 및 focus:ring-0 처리로 클릭 시 불필요한 포커스 표시 제거

🔗 참고 사항
	•	현재는 단순 alert 검증만 있으며, 실제 백엔드 연동 시에는 변환된 24시간제 값(startHour24, endHour24)을 API 요청 payload에 포함시키면 됩니다.
	•	자정 이후(예: 오후 10시 ~ 오전 2시)와 같이 跨일(overnight) 예약을 허용할지 정책적으로 정해야 합니다.

🔗 관련 이슈
	•	Close #24 