### PR TITLE
feat: api 연동 로직 구현

### DIFF
--- a/src/components/ProfileEditorModal.tsx
+++ b/src/components/ProfileEditorModal.tsx
@@ -1,11 +1,11 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import type { Profile } from "@/hooks/useProfile";
 
 type Props = {
   openActions: string[]; // ["setup-profile", "edit-profile"]
   value: Profile;
-  onSave: (patch: Partial<Profile>) => void;
+  onSave: (patch: Partial<Profile>) => void | Promise<void>; // 👈 비동기도 허용
 };
 
 export default function ProfileEditorModal({
@@ -21,9 +21,55 @@ export default function ProfileEditorModal({
   const [preview, setPreview] = useState<string | null>(
     value.avatarUrl ?? null
   );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
 
+  // 모달이 열릴 때마다 value로 폼 초기화
+  useEffect(() => {
+    if (open) {
+      setNickname(value.nickname ?? "");
+      setPreview(value.avatarUrl ?? null);
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // blob URL 누수 방지
+  useEffect(() => {
+    return () => {
+      if (preview?.startsWith("blob:")) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
+
   if (!open) return null;
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    // 간단한 유효성 검사 (닉네임은 선택 입력이지만 공백만은 허용 X)
+    const trimmed = nickname.trim();
+    const patch: Partial<Profile> = {
+      nickname: trimmed || null,
+      avatarUrl: preview, // 현재는 미리보기 URL(파일 업로드는 부모에서 처리 권장)
+      mannerTemp: value.mannerTemp ?? 100, // 최초 생성 시 100 보장
+    };
+
+    try {
+      setSaving(true);
+      // onSave가 동기/비동기 모두 자연스럽게 처리
+      await Promise.resolve(onSave(patch));
+      // 성공 시에만 닫기
+      setParams({});
+    } catch (e: any) {
+      // 부모(onSave)에서 에러 throw 시 여기서 사용자에게 보여줌
+      setError(
+        e?.message || "저장 중 문제가 발생했어요. 잠시 후 다시 시도해주세요."
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div className="fixed inset-0 p-1 bg-black/40 grid place-items-center z-50">
@@ -36,20 +82,17 @@ export default function ProfileEditorModal({
             <div className="relative size-20 rounded-full overflow-hidden bg-neutral-200 grid place-items-center">
               {preview ? (
                 <>
-                  {/* 배경 이미지 (전체 덮기) */}
                   <img
                     src={preview}
                     alt="preview"
                     className="absolute inset-0 w-full h-full object-cover blur-sm"
                   />
-
-                  {/* 반투명 오버레이 + 중앙 버튼 컨테이너 */}
                   <div className="absolute inset-0 grid place-items-center">
                     <button
                       type="button"
-                      className="h-6 px-3 rounded bg-neutral-200 text-[10px] font-semibold
-                       text-neutral-700 hover:bg-neutral-300"
+                      className="h-6 px-3 rounded bg-neutral-200 text-[10px] font-semibold text-neutral-700 hover:bg-neutral-300 disabled:opacity-60"
                       onClick={() => setPreview(null)}
+                      disabled={saving}
                     >
                       제거
                     </button>
@@ -58,9 +101,9 @@ export default function ProfileEditorModal({
               ) : (
                 <button
                   type="button"
-                  className="h-6 px-2 rounded bg-white text-[10px] font-semibold
-                   text-blue-700 border border-blue-700 hover:bg-blue-200"
+                  className="h-6 px-2 rounded bg-white text-[10px] font-semibold text-blue-700 border border-blue-700 hover:bg-blue-200 disabled:opacity-60"
                   onClick={() => fileRef.current?.click()}
+                  disabled={saving}
                 >
                   사진 추가
                 </button>
@@ -84,38 +127,45 @@ export default function ProfileEditorModal({
               }}
             />
           </div>
+
           {/* 닉네임 입력 */}
           <div className="w-full flex flex-col justify-center p-1 gap-1">
             <label className="text-sm font-medium pl-1">닉네임</label>
             <input
-              className="h-10 rounded border border-neutral-300 px-3 outline-none focus:ring-2 focus:ring-blue-400"
+              className="h-10 rounded border border-neutral-300 px-3 outline-none focus:ring-2 focus:ring-blue-400 disabled:bg-neutral-100"
               placeholder="닉네임을 입력하세요"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
               maxLength={20}
+              disabled={saving}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !saving) handleSubmit();
+              }}
             />
           </div>
         </div>
 
+        {/* 에러 메시지 */}
+        {error && (
+          <p className="mt-3 text-sm text-red-600 px-1" role="alert">
+            {error}
+          </p>
+        )}
+
         <div className="mt-5 flex justify-end gap-2">
           <button
-            className="h-9 px-4 rounded bg-neutral-200 hover:bg-neutral-300"
+            className="h-9 px-4 rounded bg-neutral-200 hover:bg-neutral-300 disabled:opacity-60"
             onClick={() => setParams({})}
+            disabled={saving}
           >
             취소
           </button>
           <button
-            className="h-9 px-4 rounded bg-blue-600 text-white hover:bg-blue-500"
-            onClick={() => {
-              onSave({
-                nickname: nickname.trim() || null,
-                avatarUrl: preview,
-                mannerTemp: value.mannerTemp ?? 100, // 👈 초기값 100
-              });
-              setParams({});
-            }}
+            className="h-9 px-4 rounded bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-60"
+            onClick={handleSubmit}
+            disabled={saving}
           >
-            저장
+            {saving ? "저장 중…" : "저장"}
           </button>
         </div>
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,8 @@
+// src/lib/api.ts
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? "https://api.example.com",
+  headers: { "Content-Type": "application/json" },
+  // 필요시 withCredentials: true,
+});

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,0 +1,27 @@
+// src/services/user.ts
+import { api } from "@/lib/api";
+
+export type CreateUserPayload = {
+  username: string;
+  role: "ROLE_CUSTOMER" | "ROLE_OWNER" | "ROLE_ADMIN"; // 백엔드 정의에 맞춰 확장
+  point: number;
+  trust_score: number;
+};
+
+export type UserResponse = {
+  id: string;
+  username: string;
+  role: string;
+  point: number;
+  trust_score: number;
+  created_at: string;
+  // 백엔드가 추가로 주는 필드들(생성시각 등)이 있으면 여기에 확장
+};
+
+export async function createUser(
+  payload: CreateUserPayload,
+  signal?: AbortSignal
+) {
+  const res = await api.post<UserResponse>("/users", payload, { signal });
+  return res.data;
+}


### PR DESCRIPTION
✨ 요약

프로필 편집 모달을 통해 사용자가 닉네임/아바타를 수정하면, 로컬 상태를 갱신하고 추후 백엔드 API 연동을 통해 서버에도 유저 생성 요청을 보낼 수 있도록 로직을 구현했습니다.

🔗 작업 내용
	•	axios 클라이언트(src/lib/api.ts) 분리 및 공통 설정 추가
	•	createUser API 함수(src/services/user.ts) 작성
	•	ProfileEditorModal에서 입력값(닉네임, 아바타) 저장 시 onSave 콜백 호출
	•	MyPage에서 handleSave 구현 → 로컬 프로필 업데이트 + createUser API 호출
	•	AbortController를 통해 요청 취소 처리 로직 추가

💻 상세 구현 내용
	•	API 레이어 분리: api.ts에서 axios.create로 인스턴스를 만들고, services/user.ts에 createUser 함수를 작성해 API 호출을 모듈화했습니다.
	•	ProfileEditorModal:
	•	닉네임, 아바타 이미지(blob URL 미리보기) 입력 가능
	•	저장 클릭 시 onSave(patch) 호출
	•	로딩 중 중복 클릭 방지 및 에러 메시지 노출 처리
	•	MyPage:
	•	useProfile 훅으로 단일 출처 상태 관리
	•	handleSave에서 서버에 createUser POST 요청 → 성공 시 updateProfile로 로컬 프로필 갱신
	•	최초 생성 시 mannerTemp = 100 보장
	•	에러 발생 시 사용자에게 알림 표시, 취소 시 AbortController로 안전하게 요청 중단

🔗 참고 사항
	•	현재 아바타는 blob: URL 기반의 로컬 미리보기만 제공
	•	추후 이미지 업로드 기능을 추가하여 서버 URL을 받아와 avatarUrl로 저장해야 함
	•	setParams({}) 대신 action 파라미터만 제거하는 방식으로 개선 필요
	•	서버 응답(createUser 결과)을 로컬 상태에 반영할 여지도 있음



🔗 관련 이슈
	•	Close #46 